### PR TITLE
hotfix update fluent kit version to beta 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["FluentMongoDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("tn-field-key")),
+        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("tn-beta-5")),
         .package(url: "https://github.com/OpenKitten/MongoKitten.git", from: "6.0.0"),
     ],
     targets: [


### PR DESCRIPTION
This updates the fluent-kit version in the package.swift file to beta 5.

Referenced in [issue 2](https://github.com/vapor/fluent-mongo-driver/issues/2).

Currently, fluent-kit points to a branch "tn-field-key" that has been merged and deleted. As such, the package manager cannot download fluent-kit and chokes on build and test.

Here, I change fluent-kit to "tn-beta-5" (the branch "tn-field-key" was merged into).

This will probably need to change again soon.