### PR TITLE
Hop to the Fluent EventLoop in custom MongoDB requests

### DIFF
--- a/Sources/FluentMongoDriver/MongoDB+Aggregate.swift
+++ b/Sources/FluentMongoDriver/MongoDB+Aggregate.swift
@@ -64,7 +64,7 @@ extension FluentMongoDatabase {
                     namespace: MongoNamespace(to: "$cmd", inDatabase: self.raw.name),
                     sessionId: nil
                 )
-            }.decode(CountReply.self).flatMapThrowing { reply in
+            }.decode(CountReply.self).hop(to: eventLoop).flatMapThrowing { reply in
                 let reply = _MongoDBAggregateResponse(value: reply.count, decoder: BSONDecoder())
                 onOutput(reply)
             }

--- a/Sources/FluentMongoDriver/MongoDB+Delete.swift
+++ b/Sources/FluentMongoDriver/MongoDB+Delete.swift
@@ -32,7 +32,7 @@ extension FluentMongoDatabase {
                     namespace: MongoNamespace(to: "$cmd", inDatabase: self.raw.name),
                     sessionId: nil
                 )
-            }.decode(DeleteReply.self).flatMapThrowing { reply in
+            }.decode(DeleteReply.self).hop(to: eventLoop).flatMapThrowing { reply in
                 let reply = _MongoDBAggregateResponse(
                     value: reply.deletes,
                     decoder: BSONDecoder()

--- a/Sources/FluentMongoDriver/MongoDB+Schema.swift
+++ b/Sources/FluentMongoDriver/MongoDB+Schema.swift
@@ -52,7 +52,7 @@ extension FluentMongoDatabase {
                             namespace: MongoNamespace(to: "$cmd", inDatabase: self.raw.name),
                             sessionId: nil
                         )
-                    }.map { _ in }
+                    }.hop(to: eventLoop).map { _ in }
 
                     futures.append(createdIndex)
                 case .foreignKey, .custom:

--- a/Sources/FluentMongoDriver/MongoDB+Update.swift
+++ b/Sources/FluentMongoDriver/MongoDB+Update.swift
@@ -31,7 +31,7 @@ extension FluentMongoDatabase {
                     namespace: MongoNamespace(to: "$cmd", inDatabase: self.raw.name),
                     sessionId: nil
                 )
-            }.decode(UpdateReply.self).flatMapThrowing { reply in
+            }.decode(UpdateReply.self).hop(to: eventLoop).flatMapThrowing { reply in
                 let reply = _MongoDBAggregateResponse(
                     value: reply.updatedCount,
                     decoder: BSONDecoder()


### PR DESCRIPTION
In the previous PR, #10, not all queries were covered because the MongoKitten helper objects aren't being used on all requests. This PR adds hops the eventloop on the remainder of queries.