### PR TITLE
Add support for one or more sibling identifiers stored in the model

### DIFF
--- a/Sources/FluentMongoDriver/SiblingFieldProperty.swift
+++ b/Sources/FluentMongoDriver/SiblingFieldProperty.swift
@@ -10,12 +10,12 @@ public final class SiblingFieldProperty<From, To>
     where From: Fields, To: Model
 {
     public let key: FieldKey
-    public var value: To.IDValue?
-    public fileprivate(set) var model: To?
+    public var value: To?
+    public var identifier: To.IDValue?
     
     public var projectedValue: SiblingFieldProperty<From, To> { self }
 
-    public var wrappedValue: To.IDValue? {
+    public var wrappedValue: To? {
         get {
             return value
         }
@@ -29,18 +29,18 @@ public final class SiblingFieldProperty<From, To>
     }
 
     public func query(on database: Database) -> QueryBuilder<To> {
-        guard let value = self.value else {
+        guard let identifier = self.identifier else {
             fatalError("Cannot query siblings relation from unsaved model.")
         }
 
         return To.query(on: database)
-            .filter(\._$id == value)
+            .filter(\._$id == identifier)
     }
 }
 
 extension SiblingFieldProperty: PropertyProtocol {
     public typealias Model = From
-    public typealias Value = To.IDValue
+    public typealias Value = To
 }
 
 extension SiblingFieldProperty: FieldProtocol { }
@@ -53,7 +53,7 @@ extension SiblingFieldProperty: Relation {
 
     public func load(on database: Database) -> EventLoopFuture<Void> {
         self.query(on: database).first().map {
-            self.model = $0
+            self.value = $0
         }
     }
 }
@@ -90,17 +90,17 @@ extension SiblingFieldProperty: AnyProperty {
     public var path: [FieldKey] { [self.key] }
 
     public func input(to input: inout DatabaseInput) {
-        input.values[self.key] = value.map { identifiers in
+        input.values[self.key] = identifier.map { identifiers in
             return .bind(identifiers)
         }
     }
 
     public func output(from output: DatabaseOutput) throws {
         if output.contains([self.key]) {
-            self.value = nil
+            self.identifier = nil
             
             do {
-                self.value = try output.decode(self.key, as: Optional<To.IDValue>.self)
+                self.identifier = try output.decode(self.key, as: Optional<To.IDValue>.self)
             } catch {
                 throw FluentError.invalidField(
                     name: self.key.description,
@@ -112,14 +112,14 @@ extension SiblingFieldProperty: AnyProperty {
     }
 
     public func encode(to encoder: Encoder) throws {
-        if let identifier = self.value {
+        if let identifier = self.identifier {
             var container = encoder.singleValueContainer()
             try container.encode(identifier)
         }
     }
 
     public func decode(from decoder: Decoder) throws {
-        self.value = try To.IDValue(from: decoder)
+        self.identifier = try To.IDValue(from: decoder)
     }
 }
 
@@ -130,13 +130,13 @@ private struct SiblingEagerLoader<From, To>: EagerLoader
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         let done = models.map { model -> EventLoopFuture<Void> in
-            guard let id = model[keyPath: self.relationKey].value else {
+            guard let id = model[keyPath: self.relationKey].identifier else {
                 model[keyPath: self.relationKey].value = nil
                 return database.eventLoop.makeSucceededFuture(())
             }
             
             return To.query(on: database).filter(\._$id == id).first().map { result in
-                model[keyPath: self.relationKey].model = result
+                model[keyPath: self.relationKey].value = result
             }
         }
         
@@ -152,7 +152,7 @@ private struct ThroughSiblingEagerLoader<From, Through, Loader>: EagerLoader
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         let throughs = models.compactMap { model in
-            model[keyPath: self.relationKey].model
+            model[keyPath: self.relationKey].value
         }
         return self.loader.run(models: throughs, on: database)
     }

--- a/Sources/FluentMongoDriver/SiblingFieldProperty.swift
+++ b/Sources/FluentMongoDriver/SiblingFieldProperty.swift
@@ -1,6 +1,6 @@
 import FluentKit
 
-extension Model {
+extension Fields {
     public typealias SiblingField<To> = SiblingFieldProperty<Self, To>
         where To: Model
 }

--- a/Sources/FluentMongoDriver/SiblingFieldProperty.swift
+++ b/Sources/FluentMongoDriver/SiblingFieldProperty.swift
@@ -1,0 +1,159 @@
+import FluentKit
+
+extension Model {
+    public typealias SiblingField<To> = SiblingFieldProperty<Self, To>
+        where To: Model
+}
+
+@propertyWrapper
+public final class SiblingFieldProperty<From, To>
+    where From: Fields, To: Model
+{
+    public let key: FieldKey
+    public var value: To?
+    public var identifier: To.IDValue?
+    
+    public var projectedValue: SiblingFieldProperty<From, To> { self }
+
+    public var wrappedValue: To? {
+        get {
+            return value
+        }
+        set {
+            self.value = newValue
+        }
+    }
+
+    public init(key: FieldKey) {
+        self.key = key
+    }
+
+    public func query(on database: Database) -> QueryBuilder<To> {
+        guard let identifier = self.identifier else {
+            fatalError("Cannot query siblings relation from unsaved model.")
+        }
+
+        return To.query(on: database)
+            .filter(\._$id == identifier)
+    }
+}
+
+extension SiblingFieldProperty: PropertyProtocol {
+    public typealias Model = From
+    public typealias Value = To
+}
+
+extension SiblingFieldProperty: FieldProtocol { }
+extension SiblingFieldProperty: AnyField { }
+
+extension SiblingFieldProperty: Relation {
+    public var name: String {
+        return "SiblingsField<\(From.self), \(To.self)>(key: \(self.key))"
+    }
+
+    public func load(on database: Database) -> EventLoopFuture<Void> {
+        self.query(on: database).first().map {
+            self.value = $0
+        }
+    }
+}
+
+extension SiblingFieldProperty: EagerLoadable where From: FluentKit.Model {
+    public static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, From.SiblingField<To>>,
+        to builder: Builder
+    )
+        where Builder: EagerLoadBuilder, Builder.Model == From
+    {
+        let loader = SiblingEagerLoader(relationKey: relationKey)
+        builder.add(loader: loader)
+    }
+
+
+    public static func eagerLoad<Loader, Builder>(
+        _ loader: Loader,
+        through: KeyPath<From, From.SiblingField<To>>,
+        to builder: Builder
+    ) where
+        Loader: EagerLoader,
+        Loader.Model == To,
+        Builder: EagerLoadBuilder,
+        Builder.Model == From
+    {
+        let loader = ThroughSiblingEagerLoader(relationKey: through, loader: loader)
+        builder.add(loader: loader)
+    }
+}
+
+extension SiblingFieldProperty: AnyProperty {
+    public var nested: [AnyProperty] { [] }
+    public var path: [FieldKey] { [self.key] }
+
+    public func input(to input: inout DatabaseInput) {
+        input.values[self.key] = identifier.map { identifiers in
+            return .bind(identifiers)
+        }
+    }
+
+    public func output(from output: DatabaseOutput) throws {
+        if output.contains([self.key]) {
+            self.identifier = nil
+            
+            do {
+                self.identifier = try output.decode(self.key, as: Optional<To.IDValue>.self)
+            } catch {
+                throw FluentError.invalidField(
+                    name: self.key.description,
+                    valueType: [To.IDValue].self,
+                    error: error
+                )
+            }
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        if let identifier = self.identifier {
+            var container = encoder.singleValueContainer()
+            try container.encode(identifier)
+        }
+    }
+
+    public func decode(from decoder: Decoder) throws {
+        self.identifier = try To.IDValue(from: decoder)
+    }
+}
+
+private struct SiblingEagerLoader<From, To>: EagerLoader
+    where From: Model, To: Model
+{
+    let relationKey: KeyPath<From, SiblingFieldProperty<From, To>>
+
+    func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
+        let done = models.map { model -> EventLoopFuture<Void> in
+            guard let id = model[keyPath: self.relationKey].identifier else {
+                model[keyPath: self.relationKey].value = nil
+                return database.eventLoop.makeSucceededFuture(())
+            }
+            
+            return To.query(on: database).filter(\._$id == id).first().map { result in
+                model[keyPath: self.relationKey].value = result
+            }
+        }
+        
+        return EventLoopFuture.andAllSucceed(done, on: database.eventLoop)
+    }
+}
+
+private struct ThroughSiblingEagerLoader<From, Through, Loader>: EagerLoader
+    where From: Model, Loader: EagerLoader, Loader.Model == Through
+{
+    let relationKey: KeyPath<From, From.SiblingField<Through>>
+    let loader: Loader
+
+    func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
+        let throughs = models.compactMap { model in
+            model[keyPath: self.relationKey].value
+        }
+        return self.loader.run(models: throughs, on: database)
+    }
+}

--- a/Sources/FluentMongoDriver/SiblingFieldProperty.swift
+++ b/Sources/FluentMongoDriver/SiblingFieldProperty.swift
@@ -38,13 +38,10 @@ public final class SiblingFieldProperty<From, To>
     }
 }
 
-extension SiblingFieldProperty: PropertyProtocol {
+extension SiblingFieldProperty: Property {
     public typealias Model = From
     public typealias Value = To
 }
-
-extension SiblingFieldProperty: FieldProtocol { }
-extension SiblingFieldProperty: AnyField { }
 
 extension SiblingFieldProperty: Relation {
     public var name: String {
@@ -90,13 +87,13 @@ extension SiblingFieldProperty: AnyProperty {
     public var path: [FieldKey] { [self.key] }
 
     public func input(to input: inout DatabaseInput) {
-        input.values[self.key] = identifier.map { identifiers in
-            return .bind(identifiers)
-        }
+        input.set(identifier.map { identifiers in
+            .bind(identifiers)
+        } ?? .null, at: key)
     }
 
     public func output(from output: DatabaseOutput) throws {
-        if output.contains([self.key]) {
+        if output.contains(key) {
             self.identifier = nil
             
             do {

--- a/Sources/FluentMongoDriver/SiblingsFieldProperty.swift
+++ b/Sources/FluentMongoDriver/SiblingsFieldProperty.swift
@@ -1,0 +1,169 @@
+import FluentKit
+
+extension Model {
+    public typealias SiblingsField<To> = SiblingsFieldProperty<Self, To>
+        where To: Model
+}
+
+@propertyWrapper
+public final class SiblingsFieldProperty<From, To>
+    where From: Fields, To: Model
+{
+    public let key: FieldKey
+    public var value: [To]?
+    public var identifiers: [To.IDValue]?
+    
+    public var projectedValue: SiblingsFieldProperty<From, To> {
+        self
+    }
+
+    public var wrappedValue: [To] {
+        get {
+            guard let value = self.value else {
+                fatalError("Cannot access field before it is initialized or fetched: \(self.key)")
+            }
+            return value
+        }
+        set {
+            self.value = newValue
+        }
+    }
+    
+    public init(key: FieldKey) {
+        self.key = key
+    }
+
+    public func query(on database: Database) -> QueryBuilder<To> {
+        guard let identifiers = self.identifiers else {
+            fatalError("Cannot query siblings relation from unsaved model.")
+        }
+
+        return To.query(on: database)
+            .filter(\._$id ~~ identifiers)
+    }
+}
+
+extension SiblingsFieldProperty: PropertyProtocol {
+    public typealias Model = From
+    public typealias Value = [To]
+    
+}
+
+extension SiblingsFieldProperty: FieldProtocol { }
+extension SiblingsFieldProperty: AnyField { }
+
+extension SiblingsFieldProperty: Relation {
+    public var name: String {
+        return "SiblingsField<\(From.self), \(To.self)>(key: \(self.key))"
+    }
+
+    public func load(on database: Database) -> EventLoopFuture<Void> {
+        self.query(on: database).all().map {
+            self.value = $0
+        }
+    }
+}
+
+extension SiblingsFieldProperty: AnyProperty {
+    public var nested: [AnyProperty] { [] }
+    public var path: [FieldKey] { [self.key] }
+
+    public func input(to input: inout DatabaseInput) {
+        input.values[self.key] = identifiers.map { identifiers in
+            return .bind(identifiers)
+        }
+    }
+
+    public func output(from output: DatabaseOutput) throws {
+        if output.contains([self.key]) {
+            self.identifiers = nil
+            
+            do {
+                self.identifiers = try output.decode(self.key, as: [To.IDValue].self)
+            } catch {
+                throw FluentError.invalidField(
+                    name: self.key.description,
+                    valueType: [To.IDValue].self,
+                    error: error
+                )
+            }
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        if let identifiers = self.identifiers {
+            var container = encoder.singleValueContainer()
+            try container.encode(identifiers)
+        }
+    }
+
+    public func decode(from decoder: Decoder) throws {
+        self.identifiers = try [To.IDValue](from: decoder)
+    }
+}
+
+extension SiblingsFieldProperty: EagerLoadable where From: FluentKit.Model {
+    public static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, SiblingsFieldProperty<From, To>>,
+        to builder: Builder
+    ) where
+        Builder : EagerLoadBuilder,
+        Builder.Model == From
+    {
+        builder.add(loader: SiblingsEagerLoader(relationKey: relationKey))
+    }
+    
+    public static func eagerLoad<Loader, Builder>(
+        _ loader: Loader,
+        through relationKey: KeyPath<From, SiblingsFieldProperty<From, To>>,
+        to builder: Builder
+    ) where
+        Loader : EagerLoader,
+        Builder : EagerLoadBuilder,
+        Builder.Model == From,
+        Loader.Model == To
+    {
+        builder.add(loader: SiblingsEagerLoader(relationKey: relationKey))
+    }
+}
+
+private struct SiblingsEagerLoader<From, To>: EagerLoader
+    where From: Model, To: Model
+{
+    let relationKey: KeyPath<From, SiblingsFieldProperty<From, To>>
+
+    func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
+        let done = models.map { model -> EventLoopFuture<Void> in
+            guard let ids = model[keyPath: self.relationKey].identifiers else {
+                model[keyPath: self.relationKey].value = []
+                return database.eventLoop.makeSucceededFuture(())
+            }
+            
+            return To.query(on: database).filter(\._$id ~~ ids).all().map { results in
+                model[keyPath: self.relationKey].value = results
+            }
+        }
+        
+        return EventLoopFuture.andAllSucceed(done, on: database.eventLoop)
+    }
+}
+
+private struct ThroughSiblingsEagerLoader<From, Through, Loader>: EagerLoader
+    where From: Model, Loader: EagerLoader, Loader.Model == Through
+{
+    let relationKey: KeyPath<From, From.SiblingsField<Through>>
+    let loader: Loader
+
+    func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
+        let throughs = models.flatMap {
+            $0[keyPath: self.relationKey].value!
+        }
+        return self.loader.run(models: throughs, on: database)
+    }
+}
+
+extension EagerLoader {
+    func anyRun(models: [AnyModel], on database: Database) -> EventLoopFuture<Void> {
+        self.run(models: models.map { $0 as! Model }, on: database)
+    }
+}

--- a/Sources/FluentMongoDriver/SiblingsFieldProperty.swift
+++ b/Sources/FluentMongoDriver/SiblingsFieldProperty.swift
@@ -1,6 +1,6 @@
 import FluentKit
 
-extension Model {
+extension Fields {
     public typealias SiblingsField<To> = SiblingsFieldProperty<Self, To>
         where To: Model
 }

--- a/Tests/FluentMongoDriverTests/FluentMongoDriverTests.swift
+++ b/Tests/FluentMongoDriverTests/FluentMongoDriverTests.swift
@@ -4,93 +4,97 @@ import FluentBenchmark
 import FluentMongoDriver
 import XCTest
 
-public final class DateRange: Model {
-    public static let schema = "date-range"
+final class DateRange: Model {
+    static let schema = "date-range"
     
     @ID(key: .id)
-    public var id: UUID?
+    var id: UUID?
     
     @Field(key: "start")
-    public var start: Date
+    var start: Date
     
     @Field(key: "end")
-    public var end: Date
+    var end: Date
     
-    public init() {}
+    init() {}
     
-    public init(from: Date, to: Date) {
+    init(from: Date, to: Date) {
         self.start = from
         self.end = to
     }
 }
 
-public final class CustomIDEntity: Model {
-    public static let schema = "entities"
+final class CustomIDEntity: Model {
+    static let schema = "entities"
     
     @ID(custom: .id)
-    public var id: ObjectId?
+    var id: ObjectId?
 
     @Field(key: "name")
-    public var name: String
+    var name: String
 
-    public init() { }
+    init() { }
 
-    public init(id: ObjectId? = nil, name: String) {
+    init(id: ObjectId? = nil, name: String) {
         self.id = id
         self.name = name
     }
 }
 
-public final class NestedSiblings: Model {
-    public static let schema = "parent"
+final class NestedSiblings: Model {
+    static let schema = "parent"
     @ID(custom: .id)
-    public var id: ObjectId?
+    var id: ObjectId?
 
     @SiblingsField(key: "dates")
-    public var dates: [DateRange]
+    var dates: [DateRange]
 
-    public init() { }
+    init() { }
 
-    public init(id: ObjectId? = nil, dates: [UUID]) {
+    init(id: ObjectId? = nil, dates: [UUID]) {
         self.$dates.identifiers = dates
     }
 }
 
-public final class DocumentStorage: Model {
-    public static let schema = "documentstorages"
+final class DocumentStorage: Model {
+    static let schema = "documentstorages"
+    
+    @ID(custom: .id)
+    var id: ObjectId?
+    
     @Field(key: "document")
-    public var document: Document
+    var document: Document
 
-    public init() { }
+    init() { }
 
-    public init(id: ObjectId? = nil, document: Document) {
+    init(id: ObjectId? = nil, document: Document) {
         self.id = id
         self.document = document
     }
 }
 
-public final class Nested: Fields {
+final class Nested: Fields {
     @Field(key: "value")
-    public var value: String
+    var value: String
     
-    public init() {}
-    public init(value: String) {
+    init() {}
+    init(value: String) {
         self.value = value
     }
 }
 
-public final class NestedStorage: Model {
-    public static let schema = "documentstorages"
+final class NestedStorage: Model {
+    static let schema = "documentstorages"
     
     @ID(custom: .id)
-    public var id: ObjectId?
+    var id: ObjectId?
 
     @Field(key: "nested")
-    public var nested: Nested
+    var nested: Nested
 
-    public init() { }
+    init() { }
 
-    public init(id: ObjectId? = nil, nested: Nested) {
+    init(id: ObjectId? = nil, nested: Nested) {
         self.id = id
         self.nested = nested
     }
@@ -220,15 +224,15 @@ final class FluentMongoDriverTests: XCTestCase {
         try entity.save(on: db).wait()
         
         // This will work as long as there's one entity
-        let _sibling = try NestedSiblings.query(on: db).with(\.$dates).first().wait()
+        let _sameEntity = try NestedSiblings.query(on: db).with(\.$dates).first().wait()
         
-        guard let sibling = _sibling else {
+        guard let sameEntity = _sameEntity else {
             XCTFail("No entities found, although there was one saved")
             return
         }
         
         for i in range {
-            XCTAssertEqual(sibling.dates[i].id, siblings[i].id)
+            XCTAssertEqual(sameEntity.dates[i].id, siblings[i].id)
         }
     }
     

--- a/Tests/FluentMongoDriverTests/FluentMongoDriverTests.swift
+++ b/Tests/FluentMongoDriverTests/FluentMongoDriverTests.swift
@@ -4,6 +4,26 @@ import FluentBenchmark
 import FluentMongoDriver
 import XCTest
 
+final class DateRange: Model {
+    static let schema = "date-range"
+    
+    @ID(key: .id)
+    var id: UUID?
+    
+    @Field(key: "start")
+    var start: Date
+    
+    @Field(key: "end")
+    var end: Date
+    
+    init() {}
+    
+    init(from: Date, to: Date) {
+        self.start = from
+        self.end = to
+    }
+}
+
 final class FluentMongoDriverTests: XCTestCase {
     func testAggregate() throws {
         try self.benchmarker.testAggregate(max: false)
@@ -41,6 +61,19 @@ final class FluentMongoDriverTests: XCTestCase {
     func testTimestamp() throws { try self.benchmarker.testTimestamp() }
 //    func testTransaction() throws { try self.benchmarker.testTransaction() }
     func testUnique() throws { try self.benchmarker.testUnique() }
+    
+    func testDate() throws {
+        let range = DateRange(from: Date(), to: Date())
+        try range.save(on: db).wait()
+        
+        guard let sameRange = try DateRange.find(range.id, on: db).wait() else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertEqual(range.start, sameRange.start)
+        XCTAssertEqual(range.end, sameRange.end)
+    }
     
     var benchmarker: FluentBenchmarker {
         return .init(databases: self.dbs)

--- a/Tests/FluentMongoDriverTests/FluentMongoDriverTests.swift
+++ b/Tests/FluentMongoDriverTests/FluentMongoDriverTests.swift
@@ -47,13 +47,13 @@ public final class NestedSiblings: Model {
     @ID(custom: .id)
     public var id: ObjectId?
 
-    @SiblingsField<DateRange>(key: "dates")
-    public var dates: [UUID]
+    @SiblingsField(key: "dates")
+    public var dates: [DateRange]
 
     public init() { }
 
     public init(id: ObjectId? = nil, dates: [UUID]) {
-        self.dates = dates
+        self.$dates.identifiers = dates
     }
 }
 
@@ -142,13 +142,8 @@ final class FluentMongoDriverTests: XCTestCase {
             return
         }
         
-        guard let models = sibling.$dates.models else {
-            XCTFail("No models preresolved")
-            return
-        }
-        
         for i in range {
-            XCTAssertEqual(models[i].id, siblings[i].id)
+            XCTAssertEqual(sibling.dates[i].id, siblings[i].id)
         }
     }
     


### PR DESCRIPTION
@tanner0101 I'm not sure if this is a good time for a PR like this, with the release coming up. But I found this to be an essential tool in my own usage of the driver. As a MongoDB dev I really want to avoid using join tables. This feature will fix that for MongoDB users.

I could make this PR to Fluent, but I think SQL databases will have issues with these arrays. I'll add tests later, hence WIP.