### PR TITLE
Fix join and joinCount returning invalid results on queries where a limit is applied

### DIFF
--- a/Sources/FluentMongoDriver/MongoDB+Join.swift
+++ b/Sources/FluentMongoDriver/MongoDB+Join.swift
@@ -38,24 +38,6 @@ extension DatabaseQuery {
     func makeAggregatePipeline() throws -> [AggregateBuilderStage] {
         var stages = [AggregateBuilderStage]()
         
-        switch limits.first {
-        case .count(let n):
-            stages.append(limit(n))
-        case .custom:
-            throw FluentMongoError.unsupportedCustomLimit
-        case .none:
-            break
-        }
-        
-        switch offsets.first {
-        case .count(let offset):
-            stages.append(skip(offset))
-        case .custom:
-            throw FluentMongoError.unsupportedCustomLimit
-        case .none:
-            break
-        }
-        
         stages.append(AggregateBuilderStage(document: [
             "$replaceRoot": [
                 "newRoot": [
@@ -98,6 +80,24 @@ extension DatabaseQuery {
         
         if !filter.isEmpty {
             stages.append(match(filter))
+        }
+        
+        switch offsets.first {
+        case .count(let offset):
+            stages.append(skip(offset))
+        case .custom:
+            throw FluentMongoError.unsupportedCustomLimit
+        case .none:
+            break
+        }
+        
+        switch limits.first {
+        case .count(let n):
+            stages.append(limit(n))
+        case .custom:
+            throw FluentMongoError.unsupportedCustomLimit
+        case .none:
+            break
         }
         
         return stages

--- a/Tests/FluentMongoDriverTests/FluentMongoDriverTests.swift
+++ b/Tests/FluentMongoDriverTests/FluentMongoDriverTests.swift
@@ -104,8 +104,6 @@ final class FluentMongoDriverTests: XCTestCase {
         } catch {
             XCTFail("\(error)")
         }
-        
-        
     }
     
     func testDate() throws {


### PR DESCRIPTION
Move the limits and skips to later in the join stages. This way the limits and skips apply to the final resultset, not the initial input.