### PR TITLE
Updates to CI config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,16 +4,15 @@ on:
 jobs:
   fluent-mongo-driver_macos:
     runs-on: macos-latest
-    #env:
-      #DEVELOPER_DIR: /Applications/Xcode_11.4_beta.app/Contents/Developer
     steps:
+    # N.B.: Path expansion should cause us to select 11.4 final if present, under the assumption
+    # they won't leave the beta installed alongside it once the update.
+    - run: sudo xcode-select -s /Applications/Xcode_11.4*.app
     - run: brew tap mongodb/brew
     - run: brew install mongodb-community
     - run: brew services start mongodb/brew/mongodb-community
     - uses: actions/checkout@v2
-    - run: |
-        /usr/bin/env "DEVELOPER_DIR=$(echo /Applications/Xcode_11.4_*)" \
-        xcrun swift test --enable-test-discovery --sanitize=thread
+    - run: xcrun swift test --enable-test-discovery --sanitize=thread
       env:
         MONGO_HOSTNAME: localhost
     - run: brew services stop mongodb/brew/mongodb-community

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     # N.B.: Path expansion should cause us to select 11.4 final if present, under the assumption
     # they won't leave the beta installed alongside it once the update.
-    - run: sudo xcode-select -s /Applications/Xcode_11.4*.app
+    - run: sudo xcode-select -s /Applications/Xcode_11.4*.app/Contents/Developer
     - run: brew tap mongodb/brew
     - run: brew install mongodb-community
     - run: brew services start mongodb/brew/mongodb-community

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,7 @@ jobs:
   fluent-mongo-driver_macos:
     runs-on: macos-latest
     steps:
-    - run: ls -la /Applications/
-    - run: sudo xcode-select -p
-    - run: xcode-select -p
-    - run: sudo xcode-select -s /Applications/Xcode_11.4_beta.app/Contents/Developer
+    - run: sudo xcode-select -s /Applications/Xcode_11.4.app/Contents/Developer
     - run: brew tap mongodb/brew
     - run: brew install mongodb-community
     - run: brew services start mongodb/brew/mongodb-community

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,10 @@ jobs:
   fluent-mongo-driver_macos:
     runs-on: macos-latest
     steps:
-    # N.B.: Path expansion should cause us to select 11.4 final if present, under the assumption
-    # they won't leave the beta installed alongside it once the update.
-    - run: sudo xcode-select -s /Applications/Xcode_11.4*.app/Contents/Developer
+    - run: ls -la /Applications/
+    - run: sudo xcode-select -p
+    - run: xcode-select -p
+    - run: sudo xcode-select -s /Applications/Xcode_11.4_beta.app/Contents/Developer
     - run: brew tap mongodb/brew
     - run: brew install mongodb-community
     - run: brew services start mongodb/brew/mongodb-community

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,24 @@ name: test
 on:
 - pull_request
 jobs:
+  fluent-mongo-driver_macos:
+    runs-on: macos-latest
+    #env:
+      #DEVELOPER_DIR: /Applications/Xcode_11.4_beta.app/Contents/Developer
+    steps:
+    - run: brew tap mongodb/brew
+    - run: brew install mongodb-community
+    - run: brew services start mongodb/brew/mongodb-community
+    - uses: actions/checkout@v2
+    - run: |
+        /usr/bin/env "DEVELOPER_DIR=$(echo /Applications/Xcode_11.4_*)" \
+        xcrun swift test --enable-test-discovery --sanitize=thread
+      env:
+        MONGO_HOSTNAME: localhost
+    - run: brew services stop mongodb/brew/mongodb-community
   fluent-mongo-driver_xenial:
     container: 
-      image: vapor/swift:5.2-xenial
+      image: vapor/swift:5.2-xenial-ci
     services:
       mongo:
         image: mongo
@@ -12,13 +27,13 @@ jobs:
           - 27017:27017
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - run: swift test --enable-test-discovery --sanitize=thread
       env:
         MONGO_HOSTNAME: mongo
   fluent-mongo-driver_bionic:
     container: 
-      image: vapor/swift:5.2-bionic
+      image: vapor/swift:5.2-bionic-ci
     services:
       mongo:
         image: mongo
@@ -26,7 +41,7 @@ jobs:
           - 27017:27017
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - run: swift test --enable-test-discovery --sanitize=thread
       env:
         MONGO_HOSTNAME: mongo


### PR DESCRIPTION
Use new `-ci` Docker images, update the `checkout` action, add macOS config with experimental "detect Xcode 11.4 when it shows up but still use the beta until then" trick, and also experimentally, use Homebrew to set up a MongoDB instance to test against.

This PR should _NOT_ get a `semver` label; there is no need for or value in making a release of the package for these changes