### PR TITLE
Added FluentBenchmarker.testGroupBy test case to FluentMongoDriverTests

### DIFF
--- a/Tests/FluentMongoDriverTests/FluentMongoDriverTests.swift
+++ b/Tests/FluentMongoDriverTests/FluentMongoDriverTests.swift
@@ -96,6 +96,7 @@ final class FluentMongoDriverTests: XCTestCase {
     func testCRUD() throws { try self.benchmarker.testCRUD() }
     func testEagerLoad() throws { try self.benchmarker.testEagerLoad() }
     func testEnum() throws { try self.benchmarker.testEnum() }
+    func testGroupBy() throws { try self.benchmarker.testGroupBy() }
     func testGroup() throws { try self.benchmarker.testGroup() }
     func testID() throws {
         try self.benchmarker.testID(


### PR DESCRIPTION
The driver still needs to be updated to use the `DatabaseQuery.groups` property in read and aggregate queries.