### PR TITLE
Fix build error with new Fluent support for models with composite primary keys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
         dbimage:
           - mongo
         runner:
-          - swift:5.2-focal
+          - swift:5.4-focal
           - swift:5.5-focal
           - swift:5.6-focal
           - swiftlang/swift:nightly-main-focal
@@ -24,7 +24,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Run tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread
+        run: swift test --sanitize=thread
         env:
           MONGO_HOSTNAME_A: mongo-a
           MONGO_HOSTNAME_B: mongo-b

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "FluentMongoDriver", targets: ["FluentMongoDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("composite-primary-key-models")),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.27.0"),
         .package(url: "https://github.com/OpenKitten/MongoKitten.git", from: "6.6.4"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "FluentMongoDriver", targets: ["FluentMongoDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.24.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("composite-primary-key-models")),
         .package(url: "https://github.com/OpenKitten/MongoKitten.git", from: "6.6.4"),
     ],
     targets: [

--- a/Sources/FluentMongoDriver/MongoDB+Schema.swift
+++ b/Sources/FluentMongoDriver/MongoDB+Schema.swift
@@ -21,7 +21,7 @@ extension FluentMongoDatabase {
                     continue nextConstraint
                 }
                 switch algorithm {
-                case .unique(let fields):
+                case .unique(let fields), .compositeIdentifier(let fields):
                     let indexKeys = try fields.map { field -> String in
                         switch field {
                         case .key(let key):

--- a/Tests/FluentMongoDriverTests/FluentMongoDriverTests.swift
+++ b/Tests/FluentMongoDriverTests/FluentMongoDriverTests.swift
@@ -91,6 +91,7 @@ final class FluentMongoDriverTests: XCTestCase {
     func testBatch() throws { try self.benchmarker.testBatch() }
     func testChildren() throws { try self.benchmarker.testChildren() }
     func testChunk() throws { try self.benchmarker.testChunk() }
+    func testCompositeID() throws { try self.benchmarker.testCompositeID() }
     func testCRUD() throws { try self.benchmarker.testCRUD() }
     func testEagerLoad() throws { try self.benchmarker.testEagerLoad() }
     func testEnum() throws { try self.benchmarker.testEnum() }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,2 +1,0 @@
-#error("Please test with `swift test --enable-test-discovery`")
-


### PR DESCRIPTION
Also follows suit with other Vapor packages, plus NIO, by dropping support for Swift 5.2 and 5.3.