### PR TITLE
Add support for sorting joined tables

### DIFF
--- a/Sources/FluentMongoDriver/DatabaseQuery+Mongo.swift
+++ b/Sources/FluentMongoDriver/DatabaseQuery+Mongo.swift
@@ -2,17 +2,11 @@ import FluentKit
 import MongoKitten
 
 extension DatabaseQuery {
-    internal func makeMongoDBSort() throws -> MongoKitten.Sort? {
+    internal func makeMongoDBSort(aggregate: Bool) throws -> MongoKitten.Sort? {
         var sortSpec = [(String, SortOrder)]()
         
         for sort in sorts {
-            switch sort {
-            case .sort(let field, let direction):
-                let path = try field.makeMongoPath()
-                try sortSpec.append((path, direction.makeMongoDirection()))
-            case .custom:
-                throw FluentMongoError.unsupportedCustomSort
-            }
+            sortSpec.append(try sort.makeMongoDBSort(aggregate: aggregate))
         }
         
         if sortSpec.isEmpty {

--- a/Sources/FluentMongoDriver/MongoDB+Join.swift
+++ b/Sources/FluentMongoDriver/MongoDB+Join.swift
@@ -123,6 +123,10 @@ extension DatabaseQuery {
             stages.append(match(filter))
         }
         
+        if let mongoDBSort = try makeMongoDBSort(aggregate: true) {
+            stages.append(sort(mongoDBSort))
+        }
+        
         switch offsets.first {
         case .count(let offset):
             stages.append(skip(offset))

--- a/Sources/FluentMongoDriver/MongoDB+Read.swift
+++ b/Sources/FluentMongoDriver/MongoDB+Read.swift
@@ -37,7 +37,7 @@ extension FluentMongoDatabase {
             }
             find.command.projection = projection.document
             
-            find.command.sort = try query.makeMongoDBSort()?.document
+            find.command.sort = try query.makeMongoDBSort(aggregate: false)?.document
             
             logger.debug("fluent-mongo find command=\(find.command)")
             let decoder = BSONDecoder()

--- a/Sources/FluentMongoDriver/Sort.swift
+++ b/Sources/FluentMongoDriver/Sort.swift
@@ -15,3 +15,22 @@ extension DatabaseQuery.Sort.Direction {
         }
     }
 }
+
+extension DatabaseQuery.Sort {
+    internal func makeMongoDBSort(aggregate: Bool) throws -> (String, SortOrder) {
+        switch self {
+        case .sort(let field, let direction):
+            let path: String
+            
+            if aggregate {
+                path = try field.makeProjectedMongoPath()
+            } else {
+                path = try field.makeMongoPath()
+            }
+            
+            return try (path, direction.makeMongoDirection())
+        case .custom:
+            throw FluentMongoError.unsupportedCustomSort
+        }
+    }
+}


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
### Issue
Mongo driver didn't support to query results with sorting option for joined tables as describing [here](https://docs.vapor.codes/fluent/query/#join).

<!-- When this PR is merged, the title and body will be -->
Enable sorting for joined tables
<!-- used to generate a release automatically. -->
