### PR TITLE
Add minimal support for the new `.advancedJoin()` join type in Fluent

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,9 @@ let package = Package(
         .library(name: "FluentMongoDriver", targets: ["FluentMongoDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.36.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.37.0"),
         .package(url: "https://github.com/OpenKitten/MongoKitten.git", from: "6.6.4"),
+        .package(url: "https://github.com/OpenKitten/BSON.git", from: "7.0.30"),
     ],
     targets: [
         .target(

--- a/Sources/FluentMongoDriver/FieldKey+Mongo.swift
+++ b/Sources/FluentMongoDriver/FieldKey+Mongo.swift
@@ -18,9 +18,7 @@ extension FieldKey {
 extension DatabaseQuery.Field {
     func makeMongoPath() throws -> String {
         switch self {
-        case .path(let path, _):
-            return path.map { $0.makeMongoKey() }.joined(separator: ".")
-        case .extendedPath(let path, _, _):
+        case .path(let path, _), .extendedPath(let path, _, _):
             return path.map { $0.makeMongoKey() }.joined(separator: ".")
         case .custom:
             throw FluentMongoError.unsupportedField
@@ -29,12 +27,9 @@ extension DatabaseQuery.Field {
 
     func makeProjectedMongoPath() throws -> String {
         switch self {
-        case .path(let path, let schema):
+        case .path(let path, let schema), .extendedPath(let path, let schema, nil):
             return "\(schema).\(path.map { $0.makeMongoKey() }.joined(separator: "."))"
-        case .extendedPath(let path, let schema, let space):
-            guard space == nil else { fatalError("unsupported") }
-            return "\(schema).\(path.map { $0.makeMongoKey() }.joined(separator: "."))"
-        case .custom:
+        case .extendedPath(_, _, _), .custom:
             throw FluentMongoError.unsupportedField
         }
     }

--- a/Sources/FluentMongoDriver/MongoDB+Join.swift
+++ b/Sources/FluentMongoDriver/MongoDB+Join.swift
@@ -97,7 +97,7 @@ extension DatabaseQuery {
                 case .custom:
                     throw FluentMongoError.unsupportedJoin
                 }
-            case .advancedJoin(let schema, let space, let alias, let method, let filters) where space == nil && filters.count == 1:
+            case .advancedJoin(let schema, nil, let alias, let method, let filters) where filters.count == 1:
                 guard case .field(let lKey, let fMethod, let fKey) = filters[0], case .equality(inverse: false) = fMethod else {
                     throw FluentMongoError.unsupportedJoin
                 }


### PR DESCRIPTION
Restores compatibility with FluentKit 1.37.0