### PR TITLE
Add API Docs

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,18 +1,14 @@
 name: deploy-api-docs
 on:
-   push:
-     branches:
-       - main
+  push:
+    branches:
+      - main
 
 jobs:
-  deploy:
-    name: api.vapor.codes
-    runs-on: ubuntu-latest
-    steps:
-    - name: Deploy api-docs
-      uses: appleboy/ssh-action@master
-      with:
-        host: vapor.codes
-        username: vapor
-        key: ${{ secrets.VAPOR_CODES_SSH_KEY }}
-        script: ./github-actions/deploy-api-docs.sh
+  build-and-deploy:
+     uses: vapor/api-docs/.github/workflows/build-and-deploy-docs-workflow.yml@main
+     secrets: inherit
+     with:
+       package_name: fluent-mongo-driver
+       modules: FluentMongoDriver
+       pathsToInvalidate: /fluentmongodriver

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,3 +114,14 @@ jobs:
         uses: actions/checkout@v3
       - name: Run all tests
         run: swift test --sanitize=thread
+
+  test-exports:
+    name: Test exports
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Vapor
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Build
+        run: swift build -Xswiftc -DBUILDING_DOCC

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,3 +1,5 @@
 version: 1
 metadata:
-  authors: “Maintained by the Vapor Core Team with hundreds of contributions from the Vapor Community.”
+  authors: "Maintained by the Vapor Core Team with hundreds of contributions from the Vapor Community."
+external_links:
+  documentation: "https://api.vapor.codes/fluentmongodriver/documentation/fluentmongodriver/"

--- a/Sources/FluentMongoDriver/Docs.docc/index.md
+++ b/Sources/FluentMongoDriver/Docs.docc/index.md
@@ -1,0 +1,3 @@
+# ``FluentMongoDriver``
+
+FluentMongoDriver is a package to integrate MongoKitten with FluentKit to make it easy to use and write database operations in Swift.

--- a/Sources/FluentMongoDriver/Exports.swift
+++ b/Sources/FluentMongoDriver/Exports.swift
@@ -1,4 +1,8 @@
+#if !BUILDING_DOCC
+
 @_exported import struct BSON.ObjectId
 @_exported import struct MongoKitten.GridFSFile
 @_exported import struct BSON.Document
 @_exported import protocol BSON.Primitive
+
+#endif

--- a/Tests/FluentMongoDriverTests/FluentMongoDriverTests.swift
+++ b/Tests/FluentMongoDriverTests/FluentMongoDriverTests.swift
@@ -3,6 +3,7 @@ import NIO
 import FluentBenchmark
 import FluentMongoDriver
 import XCTest
+import MongoKitten
 
 final class DateRange: Model {
     static let schema = "date-range"


### PR DESCRIPTION
Migrates the API docs for DocC. Also fixes the imports for DocC generation otherwise anything exported is added to the docs, and then any exported dependencies that export their own dependencies are added, and so on (initial attempts at Vapor had 50k symbols for everything in Foundation).
